### PR TITLE
Support array return value in `and_returns`

### DIFF
--- a/lib/Module/Spy.pm
+++ b/lib/Module/Spy.pm
@@ -188,7 +188,10 @@ sub new {
         }
 
         if (exists $RETURNS{$code_addr}) {
-            return $RETURNS{$code_addr};
+            if (@{$RETURNS{$code_addr}} == 1) {
+                return $RETURNS{$code_addr}->[0];
+            }
+            return @{$RETURNS{$code_addr}};
         }
 
         if ($CALL_THROUGH{$code_addr}) {
@@ -232,8 +235,8 @@ sub calls_reset {
 }
 
 sub returns {
-    my ($self, $value) = @_;
-    $RETURNS{refaddr($self)} = $value;
+    my $self = shift;
+    $RETURNS{refaddr($self)} = \@_;
 }
 
 sub call_through {

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -93,6 +93,19 @@ subtest 'Spy class method', sub {
         # Then return value is 3
         is(X->y, 3);
     };
+
+    subtest 'Stub-out by array value', sub {
+        # Given set spy
+        my $spy = spy_on('X', 'y');
+
+        # When set return value as (3, 5)
+        is refaddr($spy->and_returns(3, 5)), refaddr($spy);
+
+        # Then return value is (3, 5)
+        my @ret = X->y;
+        is($ret[0], 3);
+        is($ret[1], 5);
+    };
 };
 
 subtest 'Spy instance method', sub {


### PR DESCRIPTION
Hello.
I was troubled to use Module-Spy in this case.

```
my $spy = spy_on('X, 'y');
$spy->returns(3, 5);

my ($a, b) = X->y;

say $a; # 3
say $b; # undef !!
```

I want to be able to return array value, so I fixed it.
Thank you.