### PR TITLE
Load a class that to be spied to suppress `Subroutine XXX redefined` warning

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'perl', '5.008001';
 requires 'parent';
+requires 'Class::Load';
 requires 'Scalar::Util';
 
 on 'test' => sub {

--- a/lib/Module/Spy.pm
+++ b/lib/Module/Spy.pm
@@ -123,9 +123,12 @@ sub DESTROY {
 package Module::Spy::Class;
 our @ISA=('Module::Spy::Base');
 
+use Class::Load qw(load_class);
+
 sub new {
     my $class = shift;
     my ($stuff, $method) = @_;
+    load_class($stuff); # $stuff is a class in Module::Spy::Class
 
     my $self = bless { stuff => $stuff, method => $method }, $class;
 

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -5,14 +5,12 @@ use Test::More;
 use Module::Spy;
 use Scalar::Util qw(refaddr);
 
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use X;
+
 $|++;
 
-{
-    package X;
-    our $Y_CNT = 0;
-    sub new { bless {}, shift }
-    sub y { $Y_CNT++; 'yyy' }
-}
 
 subtest 'Spy class method', sub {
     subtest 'Not called yet', sub {

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -11,6 +11,17 @@ use X;
 
 $|++;
 
+subtest 'Spy class method (not required yet)' => sub {
+    my $last_warning;
+    local $SIG{__WARN__} = sub { $last_warning = $_[0] };
+
+    ok ! exists $INC{'Truman.pm'};
+
+    my $spy = spy_on('Truman', 'name');
+    require Truman;
+
+    is $last_warning, undef;
+};
 
 subtest 'Spy class method', sub {
     subtest 'Not called yet', sub {

--- a/t/02_calls.t
+++ b/t/02_calls.t
@@ -4,6 +4,10 @@ use utf8;
 use Test::More;
 use Module::Spy;
 
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use X;
+
 subtest 'calls_any', sub {
     my $spy = spy_on('X', 'y');
     ok !$spy->calls_any;

--- a/t/lib/Truman.pm
+++ b/t/lib/Truman.pm
@@ -1,0 +1,8 @@
+package Truman;
+
+use strict;
+use warnings;
+
+sub name { 'Truman' }
+
+1;

--- a/t/lib/X.pm
+++ b/t/lib/X.pm
@@ -1,0 +1,5 @@
+package X;
+our $Y_CNT = 0;
+sub new { bless {}, shift }
+sub y { $Y_CNT++; 'yyy' }
+1;


### PR DESCRIPTION
If we created a spy for a class that not loaded yet and then require it, we encountered a warning such as `Subroutine XXX redefined`.

In contrast, Test::Mock::Guard does not generate the warnings because it `require`s the class at first:

https://metacpan.org/source/XAICRON/Test-Mock-Guard-0.10/lib/Test/Mock/Guard.pm#L41

In my opinion, we should also follow that manner.